### PR TITLE
Migrate to NextAuth v5 auth API and simplify Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,21 +5,12 @@ datasource db {
  provider = "sqlite"
  url      = env("DATABASE_URL")
 }
-enum Role {
- DOCTOR
- SECRETARY
-}
-enum AppointmentStatus {
- BOOKED
- COMPLETED
- CANCELLED
-}
 model User {
  id           Int      @id @default(autoincrement())
  name         String
  email        String   @unique
  passwordHash String
- role         Role     @default(SECRETARY)
+ role         String   @default("SECRETARY")
  createdAt    DateTime @default(now())
  appointments Appointment[] @relation("DoctorAppointments")
  createdAppointments Appointment[] @relation("CreatedByAppointments")
@@ -43,7 +34,7 @@ model Appointment {
  timeFrom   String
  timeTo     String
  reason     String?
- status     AppointmentStatus @default(BOOKED)
+ status     String   @default("BOOKED")
  patient    Patient  @relation(fields: [patientId], references: [id])
  patientId  Int
  doctor     User     @relation("DoctorAppointments", fields: [doctorId], references: [id])

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,8 +1,8 @@
-import { getServerSession } from "next-auth";
-import { authConfig } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+
 export default async function DashboardPage() {
- const session = await getServerSession(authConfig);
+ await auth();
  const [patients, todayAppts, prescriptions] = await Promise.all([
   prisma.patient.count(),
   prisma.appointment.count({

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,19 +1,19 @@
 import { ReactNode } from "react";
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { authConfig } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 import Topbar from "@/components/Topbar";
 import Container from "@/components/Container";
 import "@/styles/globals.css";
+
 export default async function ProtectedLayout({ children }: { children: ReactNode }) {
- const session = await getServerSession(authConfig);
- if (!session) redirect("/signin");
- return (
-  <html lang="ar" dir="rtl">
-   <body className="bg-slate-50 text-slate-900">
-    <Topbar user={session.user as any} />
-    <Container>{children}</Container>
-   </body>
-  </html>
- );
+  const session = await auth();
+  if (!session) redirect("/signin");
+  return (
+    <html lang="ar" dir="rtl">
+      <body className="bg-slate-50 text-slate-900">
+        <Topbar user={session.user as any} />
+        <Container>{children}</Container>
+      </body>
+    </html>
+  );
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,4 +1,3 @@
-import NextAuth from "next-auth";
-import { authConfig } from "@/lib/auth";
-const handler = NextAuth(authConfig);
-export { handler as GET, handler as POST };
+import { handlers } from "@/lib/auth";
+
+export const { GET, POST } = handlers;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,38 +1,37 @@
-import type { NextAuthConfig } from "next-auth";
+import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
 import { prisma } from "@/lib/prisma";
-export const authConfig = {
-session: { strategy: "jwt" },
-pages: { signIn: "/signin" },
-providers: [
-Credentials({
-credentials: {
-email: { label: "Email", type: "email" },
-password: { label: "Password", type: "password" },
-},
-authorize: async (creds) => {
-const email = String(creds?.email || "").toLowerCase();
-const user = await prisma.user.findUnique({ where: { email } });
-if (!user) return null;
-const ok = await bcrypt.compare(String(creds?.password || ""),
-user.passwordHash);
-if (!ok) return null;
-return { id: String(user.id), name: user.name, email: user.email, role:
-user.role } as any;
-},
-}),
-],
-callbacks: {
-async jwt({ token, user }) {
-if (user) {
-token.role = (user as any).role;
-}
-return token;
-},
-async session({ session, token }) {
-(session.user as any).role = token.role;
-return session;
-},
-},
-} satisfies NextAuthConfig;
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  session: { strategy: "jwt" },
+  pages: { signIn: "/signin" },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      authorize: async (creds) => {
+        const email = String(creds?.email || "").toLowerCase();
+        const user = await prisma.user.findUnique({ where: { email } });
+        if (!user) return null;
+        const ok = await bcrypt.compare(String(creds?.password || ""), user.passwordHash);
+        if (!ok) return null;
+        return { id: String(user.id), name: user.name, email: user.email, role: user.role } as any;
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      (session.user as any).role = token.role;
+      return session;
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- switch to NextAuth v5 `auth` and `handlers` exports
- protect pages using `auth()` instead of `getServerSession`
- remove unsupported Prisma enums and regenerate client

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc7822a8832196a9969f003fc667